### PR TITLE
Add alias for experimental sycl namespace

### DIFF
--- a/src/Graphics/D3D12/Utils/CommandListType.hpp
+++ b/src/Graphics/D3D12/Utils/CommandListType.hpp
@@ -33,7 +33,7 @@
 
 namespace sgl { namespace d3d12 {
 
-// Corresponds to D3D12_COMMAND_LIST_TYPE_DIRECT.
+// Corresponds to D3D12_COMMAND_LIST_TYPE.
 enum class CommandListType {
     DIRECT = 0, BUNDLE = 1, COMPUTE = 2, COPY = 3, VIDEO_DECODE = 4, VIDEO_PROCESS = 5, VIDEO_ENCODE = 6, MAX_VAL = 7
 };

--- a/src/Graphics/D3D12/Utils/Device.hpp
+++ b/src/Graphics/D3D12/Utils/Device.hpp
@@ -86,7 +86,7 @@ private:
     // Device information (retrieved from adapter).
     std::string adapterName;
     uint32_t vendorId;
-    uint32_t adapterLuid;
+    uint64_t adapterLuid;
 };
 
 }}

--- a/tests/D3D12/TestSyclD3D12.cpp
+++ b/tests/D3D12/TestSyclD3D12.cpp
@@ -445,7 +445,7 @@ TEST_P(InteropTestSyclD3D12Image, ImageD3D12WriteSyclReadTests) {
         stream.syclQueuePtr = syclQueue;
         sycl::event waitSemaphoreEvent{};
         fence->waitFenceComputeApi(stream, timelineValue, &waitSemaphoreEvent);
-        sycl::ext::oneapi::experimental::unsampled_image_handle imageSyclHandle{};
+        syclexp::unsampled_image_handle imageSyclHandle{};
         imageSyclHandle.raw_handle = imageInteropSycl->getRawHandle();
         sycl::event copyEventImg = copySyclBindlessImageToBuffer(
                 *syclQueue, imageSyclHandle, formatInfo, width, height, devicePtr, waitSemaphoreEvent);
@@ -580,7 +580,7 @@ TEST_P(InteropTestSyclD3D12Image, ImageSyclWriteD3D12ReadTests) {
         // Write data with SYCL.
         sgl::StreamWrapper stream{};
         stream.syclQueuePtr = syclQueue;
-        sycl::ext::oneapi::experimental::unsampled_image_handle imageSyclHandle{};
+        syclexp::unsampled_image_handle imageSyclHandle{};
         imageSyclHandle.raw_handle = imageInteropSycl->getRawHandle();
         sycl::event writeImgEvent = writeSyclBindlessImageIncreasingIndices(
                 *syclQueue, imageSyclHandle, formatInfo, width, height);

--- a/tests/SYCL/SyclDeviceCode.cpp
+++ b/tests/SYCL/SyclDeviceCode.cpp
@@ -44,7 +44,7 @@ sycl::event writeSyclBufferData(sycl::queue& queue, size_t numEntries, float* de
 
 template<typename T, int C>
 sycl::event copySyclBindlessImageToBuffer(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img, size_t width, size_t height,
+        sycl::queue& queue, syclexp::unsampled_image_handle img, size_t width, size_t height,
         T* devicePtr, const sycl::event& depEvent) {
     auto event = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(depEvent);
@@ -52,7 +52,7 @@ sycl::event copySyclBindlessImageToBuffer(
             const auto x = it[0];
             const auto y = it[1];
             const auto index = (x + y * width) * static_cast<size_t>(C);
-            auto data = sycl::ext::oneapi::experimental::fetch_image<sycl::vec<T, C>>(img, sycl::int2{x, y});
+            auto data = syclexp::fetch_image<sycl::vec<T, C>>(img, sycl::int2{x, y});
             for (int c = 0; c < C; c++) {
                 devicePtr[index + c] = data[c];
             }
@@ -62,7 +62,7 @@ sycl::event copySyclBindlessImageToBuffer(
 }
 
 sycl::event copySyclBindlessImageToBuffer(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img,
+        sycl::queue& queue, syclexp::unsampled_image_handle img,
         const sgl::FormatInfo& formatInfo, size_t width, size_t height,
         void* devicePtr, const sycl::event& depEvent) {
     if (formatInfo.numChannels == 1 && formatInfo.channelFormat == sgl::ChannelFormat::FLOAT32) {
@@ -90,7 +90,7 @@ sycl::event copySyclBindlessImageToBuffer(
 
 template<typename T, int C>
 sycl::event writeSyclBindlessImageIncreasingIndices(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img, size_t width, size_t height) {
+        sycl::queue& queue, syclexp::unsampled_image_handle img, size_t width, size_t height) {
     auto event = queue.submit([&](sycl::handler& cgh) {
         cgh.parallel_for(sycl::range<2>{width, height}, [=](sycl::id<2> it) {
             const auto x = it[0];
@@ -100,14 +100,14 @@ sycl::event writeSyclBindlessImageIncreasingIndices(
             for (int c = 0; c < C; c++) {
                 data[c] = T(index + c);
             }
-            sycl::ext::oneapi::experimental::write_image<sycl::vec<T, C>>(img, sycl::int2{x, y}, data);
+            syclexp::write_image<sycl::vec<T, C>>(img, sycl::int2{x, y}, data);
         });
     });
     return event;
 }
 
 sycl::event writeSyclBindlessImageIncreasingIndices(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img,
+        sycl::queue& queue, syclexp::unsampled_image_handle img,
         const sgl::FormatInfo& formatInfo, size_t width, size_t height) {
     if (formatInfo.numChannels == 1 && formatInfo.channelFormat == sgl::ChannelFormat::FLOAT32) {
         return writeSyclBindlessImageIncreasingIndices<float, 1>(queue, img, width, height);

--- a/tests/SYCL/SyclDeviceCode.hpp
+++ b/tests/SYCL/SyclDeviceCode.hpp
@@ -34,11 +34,11 @@
 
 DLL_OBJECT_SYCL sycl::event writeSyclBufferData(sycl::queue& queue, size_t numEntries, float* devicePtr);
 DLL_OBJECT_SYCL sycl::event copySyclBindlessImageToBuffer(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img,
+        sycl::queue& queue, syclexp::unsampled_image_handle img,
         const sgl::FormatInfo& formatInfo, size_t width, size_t height,
         void* devicePtr, const sycl::event& depEvent);
 DLL_OBJECT_SYCL sycl::event writeSyclBindlessImageIncreasingIndices(
-        sycl::queue& queue, sycl::ext::oneapi::experimental::unsampled_image_handle img,
+        sycl::queue& queue, syclexp::unsampled_image_handle img,
         const sgl::FormatInfo& formatInfo, size_t width, size_t height);
 
 #endif //SGL_TESTS_SYCLDEVICECODE_HPP

--- a/tests/SYCL/TestSycl.cpp
+++ b/tests/SYCL/TestSycl.cpp
@@ -80,7 +80,7 @@ TEST_F(TestSycl, WriteKernelImageTest) {
         GTEST_SKIP() << "External bindless images import not supported.";
     }
 
-    sycl::ext::oneapi::experimental::image_descriptor imageDescriptor{};
+    syclexp::image_descriptor imageDescriptor{};
     imageDescriptor.width = 1024;
     imageDescriptor.height = 1024;
     imageDescriptor.num_channels = 1;
@@ -95,19 +95,19 @@ TEST_F(TestSycl, WriteKernelImageTest) {
     const size_t numEntries = imageDescriptor.width * imageDescriptor.height * imageDescriptor.num_channels;
     auto* hostPtr = sycl::malloc_host<float>(numEntries, *syclQueue);
 
-    std::vector<sycl::ext::oneapi::experimental::image_memory_handle_type> supportedImageMemoryHandleTypes =
-            sycl::ext::oneapi::experimental::get_image_memory_support(imageDescriptor, *syclQueue);
+    std::vector<syclexp::image_memory_handle_type> supportedImageMemoryHandleTypes =
+            syclexp::get_image_memory_support(imageDescriptor, *syclQueue);
     if (supportedImageMemoryHandleTypes.empty()) {
         GTEST_FAIL() << "No image memory handle types supported.";
     }
-    if (!sycl::ext::oneapi::experimental::is_image_handle_supported<sycl::ext::oneapi::experimental::unsampled_image_handle>(
-        imageDescriptor, sycl::ext::oneapi::experimental::image_memory_handle_type::opaque_handle, *syclQueue)) {
+    if (!syclexp::is_image_handle_supported<syclexp::unsampled_image_handle>(
+        imageDescriptor, syclexp::image_memory_handle_type::opaque_handle, *syclQueue)) {
         GTEST_FAIL() << "image_memory_handle_type::opaque_handle is not supported.";
     }
-    auto imageMemoryHandle = sycl::ext::oneapi::experimental::alloc_image_mem(imageDescriptor, *syclQueue);
+    auto imageMemoryHandle = syclexp::alloc_image_mem(imageDescriptor, *syclQueue);
 
-    sycl::ext::oneapi::experimental::unsampled_image_handle imageSyclHandle =
-            sycl::ext::oneapi::experimental::create_image(imageMemoryHandle, imageDescriptor, *syclQueue);
+    syclexp::unsampled_image_handle imageSyclHandle =
+            syclexp::create_image(imageMemoryHandle, imageDescriptor, *syclQueue);
 
     sycl::event writeImgEvent = writeSyclBindlessImageIncreasingIndices(
             *syclQueue, imageSyclHandle, formatInfo, imageDescriptor.width, imageDescriptor.height);
@@ -122,6 +122,6 @@ TEST_F(TestSycl, WriteKernelImageTest) {
     }
 
     sycl::free(hostPtr, *syclQueue);
-    sycl::ext::oneapi::experimental::destroy_image_handle(imageSyclHandle, *syclQueue);
-    sycl::ext::oneapi::experimental::free_image_mem(imageMemoryHandle, imageDescriptor.type, *syclQueue);
+    syclexp::destroy_image_handle(imageSyclHandle, *syclQueue);
+    syclexp::free_image_mem(imageMemoryHandle, imageDescriptor.type, *syclQueue);
 }

--- a/tests/Vulkan/TestSyclVulkan.cpp
+++ b/tests/Vulkan/TestSyclVulkan.cpp
@@ -614,7 +614,7 @@ TEST_P(InteropTestSyclVkImageVulkanWriteSyclRead, Formats) {
             if (useSemaphore) {
                 semaphoreVulkan->waitSemaphoreComputeApi(stream, timelineValue, &waitSemaphoreEvent);
             }
-            sycl::ext::oneapi::experimental::unsampled_image_handle imageSyclHandle{};
+            syclexp::unsampled_image_handle imageSyclHandle{};
             imageSyclHandle.raw_handle = imageInteropSycl->getRawHandle();
             sycl::event copyEventImg = copySyclBindlessImageToBuffer(
                     *syclQueue, imageSyclHandle, formatInfo, imageSettings.width, imageSettings.height,
@@ -782,7 +782,7 @@ TEST_P(InteropTestSyclVkImageSyclWriteVulkanRead, Formats) {
             // Write data with SYCL.
             sgl::StreamWrapper stream{};
             stream.syclQueuePtr = syclQueue;
-            sycl::ext::oneapi::experimental::unsampled_image_handle imageSyclHandle{};
+            syclexp::unsampled_image_handle imageSyclHandle{};
             imageSyclHandle.raw_handle = imageInteropSycl->getRawHandle();
             sycl::event writeImgEvent = writeSyclBindlessImageIncreasingIndices(
                     *syclQueue, imageSyclHandle, formatInfo, imageSettings.width, imageSettings.height);


### PR DESCRIPTION
* Added a common namespace alias to improve code readability: `namespace syclexp = sycl::ext::oneapi::experimental;`
* A couple of very minor corrections (e.g., fix the `Device.adapterLuid` data type).